### PR TITLE
Remove "experimental" export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,5 @@ module.exports = {
         hostname: 'source.unsplash.com',
       },
     ],
-  },
-  experimental: { appDir: true },
+  }
 };


### PR DESCRIPTION
With the line in, you get this warning / error message:

> Invalid next.config.js options detected: 
>  ⚠     Unrecognized key(s) in object: 'appDir' at "experimental"
>  ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
>  ⚠ App router is available by default now, `experimental.appDir` option can be safely removed.

I removed the line and the app runs ok without it