### PR TITLE
feat(blog): add search and pagination functionality

### DIFF
--- a/app/(blog)/blog/page.tsx
+++ b/app/(blog)/blog/page.tsx
@@ -1,16 +1,23 @@
+
 import type { Metadata } from 'next';
 
 import Image from 'next/image';
 import Link from 'next/link';
+import Pagination from '~/components/atoms/Pagination';
+import LocalSearch from '~/components/common/LocalSearch';
 
-import { findLatestPosts } from '~/utils/posts';
+import { findLatestPosts, getPosts } from '~/utils/posts';
 
 export const metadata: Metadata = {
   title: 'Blog',
 };
 
-export default async function Home({}) {
-  const posts = await findLatestPosts();
+export default async function Home({ searchParams }: { searchParams: { [key: string]: string | undefined } }) {
+  const result = await getPosts({
+    searchQuery: searchParams.q,
+    page: searchParams.page ? +searchParams.page : 1,
+  });
+
   return (
     <section className="mx-auto max-w-3xl px-6 py-12 sm:px-6 sm:py-16 lg:py-20">
       <header>
@@ -18,8 +25,9 @@ export default async function Home({}) {
           Blog
         </h1>
       </header>
+      <LocalSearch route="/blog" placeholder="Search for blog post..." />
       <div className="grid grid-cols-1 gap-6  p-4 md:p-0 lg:grid-cols-2">
-        {posts.map(({ slug, title, image }: { slug: string, title: string, image: string }) => (
+        {result.posts.map(({ slug, title, image }: { slug: string; title: string; image: string }) => (
           <div key={slug} className="flex flex-col overflow-hidden rounded-xl border border-gray-200 shadow-lg">
             <Link href={`/${slug}`}>
               <Image width={650} height={340} alt={title} src={`${image}`} />
@@ -27,6 +35,9 @@ export default async function Home({}) {
             </Link>
           </div>
         ))}
+      </div>
+      <div className="mt-6 flex items-center justify-center">
+        <Pagination pageNumber={searchParams.page ? +searchParams.page : 1} isNext={result.isNext} />
       </div>
     </section>
   );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "markdown-it": "^14.0.0",
     "next": "^14.1.0",
     "next-themes": "^0.2.1",
+    "query-string": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sharp": "^0.33.2",

--- a/src/components/atoms/Pagination.tsx
+++ b/src/components/atoms/Pagination.tsx
@@ -1,0 +1,47 @@
+
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { formUrlQuery } from '~/utils/utils';
+import type { PaginationProps } from '~/shared/types';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+
+const Pagination: React.FC<PaginationProps> = ({ pageNumber, isNext }) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleNavigation = (direction: 'prev' | 'next') => {
+    const nextPageNumber = direction === 'next' ? pageNumber + 1 : pageNumber - 1;
+
+    const newUrl = formUrlQuery({
+      params: searchParams.toString(),
+      key: 'page',
+      value: nextPageNumber.toString(),
+    });
+
+    router.push(newUrl);
+  };
+
+  return (
+    <div className="flex justify-between w-full">
+      <button
+        className={pageNumber == 1 ? 'invisible' : `btn btn-ghost px-4 py-2 text-sm font-semibold`}
+        onClick={() => handleNavigation('prev')}
+        disabled={pageNumber === 1}
+      >
+        <IconChevronLeft className="h-6 w-6" />
+      </button>
+      <span className="px-4 py-2 text-sm font-semibold">{pageNumber}</span>
+      <button
+        className={!isNext ? 'invisible' : 'btn btn-ghost px-4 py-2 text-sm font-semibold'}
+        onClick={() => handleNavigation('next')}
+        disabled={!isNext}
+      >
+        <IconChevronRight className="h-6 w-6" />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/components/common/LocalSearch.tsx
+++ b/src/components/common/LocalSearch.tsx
@@ -1,0 +1,65 @@
+
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import type { LocalSearchProps } from '~/shared/types';
+import { formUrlQuery, removeKeysFromUrlQuery } from '~/utils/utils';
+
+const LocalSearch: React.FC<LocalSearchProps> = ({ route, placeholder, otherClasses, label }) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const query = searchParams.get('q');
+
+  const [search, setSearch] = useState<string>(query || '');
+
+  useEffect(() => {
+    const delayDebounceFn = setTimeout(() => {
+      let newUrl = null;
+      if (search) {
+        // Form new url query with search params
+        newUrl = formUrlQuery({
+          params: searchParams.toString(),
+          key: 'q',
+          value: search,
+        });
+      } else {
+        // Remove search params from url
+        newUrl = removeKeysFromUrlQuery({
+          params: searchParams.toString(),
+          keysToRemove: ['q'],
+        });
+      }
+
+      if (newUrl) {
+        router.push(newUrl, { scroll: false });
+      }
+    }, 300);
+
+    return () => clearTimeout(delayDebounceFn);
+  }, [route, router, pathname, searchParams, query, search]);
+
+  return (
+    <div className={`mx-0 mb-1 sm:mb-4 ${otherClasses}`}>
+      {label && (
+        <label htmlFor="search-input" className="pb-1 text-xs uppercase tracking-wider">
+          {label}
+        </label>
+      )}
+      <input
+        id="search-input"
+        name="search-input"
+        autoComplete="given-search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder={placeholder}
+        type="text"
+        className="mb-2 w-full rounded-md border border-gray-400 py-2 pl-2 pr-4 shadow-md dark:text-gray-300 sm:mb-0"
+      />
+    </div>
+  );
+};
+
+export default LocalSearch;

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -232,7 +232,19 @@ type WindowSize = {
   height: number;
 };
 
+type PaginationProps = {
+  pageNumber: number;
+  isNext: boolean;
+};
+
 // WIDGETS
+type LocalSearchProps = {
+  route: string;
+  placeholder: string;
+  otherClasses?: string;
+  label?: string;
+};
+
 type HeroProps = {
   title?: string | ReactElement;
   subtitle?: string | ReactElement;
@@ -358,4 +370,15 @@ type HeaderProps = {
   showToggleTheme?: boolean;
   showRssFeed?: boolean;
   position?: 'center' | 'right' | 'left';
+};
+
+type UrlQueryParams = {
+  params: string;
+  key: string;
+  value: string | null;
+};
+
+type RemoveUrlQueryParams = {
+  params: string;
+  keysToRemove: string[];
 };

--- a/src/utils/posts.js
+++ b/src/utils/posts.js
@@ -29,6 +29,41 @@ export const fetchPosts = async () => {
 };
 
 /** */
+const POSTS_PER_PAGE = 4;
+
+export const getPosts = async (params) => {
+  const posts = await fetchPosts();
+
+  const { searchQuery, page = 1, pageSize = POSTS_PER_PAGE } = params;
+
+  // Calculate the number of posts to skip based on the page number and page size
+  const skipAmount = (page - 1) * pageSize;
+
+  let query = [];
+
+  query = [
+    {
+      title: { $regex: new RegExp(searchQuery, 'i') },
+      content: { $regex: new RegExp(searchQuery, 'i') },
+    },
+  ];
+
+  const filteredPosts = posts.filter((post) => {
+    return query.every((q) => {
+      return Object.keys(q).every((field) => {
+        return new RegExp(q[field].$regex).test(post[field]);
+      });
+    });
+  });
+
+  const data = filteredPosts.slice(skipAmount, skipAmount + pageSize);
+
+  const isNext = filteredPosts.length > skipAmount + pageSize;
+
+  return { posts: data, isNext };
+};
+
+/** */
 export const findLatestPosts = async ({ count } = {}) => {
   const _count = count || 4;
   const posts = await fetchPosts();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,12 @@
-// Function to format a number in thousands (K) or millions (M) format depending on its value
+import qs from 'query-string';
+import type { RemoveUrlQueryParams, UrlQueryParams } from '~/shared/types';
+
+/**
+ * Function to format a number in thousands (K) or millions (M) format depending on its value
+ * @param {number} number - number to format
+ * @param {number} digits - number of digits after the decimal point
+ * @returns {string} formatted number
+ */
 export const getSuffixNumber = (number: number, digits: number = 1): string => {
   const lookup = [
     { value: 1, symbol: '' },
@@ -16,4 +24,45 @@ export const getSuffixNumber = (number: number, digits: number = 1): string => {
     .reverse()
     .find((item) => number >= item.value);
   return lookupItem ? (number / lookupItem.value).toFixed(digits).replace(rx, '$1') + lookupItem.symbol : '0';
+};
+
+/**
+ * Constructs a URL query string by adding/updating a key-value pairs based on the provided parameters.
+ * @param {string} params - current URL query string
+ * @param {string} key - key to add/update
+ * @param {string} value - value associated with the key to add/update
+ * @returns {string} - updated URL query string
+ */
+export const formUrlQuery = ({ params, key, value }: UrlQueryParams): string => {
+  const currentUrl = qs.parse(params);
+
+  currentUrl[key] = value;
+
+  return qs.stringifyUrl(
+    {
+      url: window.location.pathname,
+      query: currentUrl,
+    },
+    { skipNull: true },
+  );
+};
+
+/**
+ * Constructs a URL query string by removing the specified keys from the provided parameters.
+ * @param {string} params - current URL query string
+ * @param {string[]} keysToRemove - keys to remove from the URL query string
+ * @returns {string} - updated URL query string
+ */
+export const removeKeysFromUrlQuery = ({ params, keysToRemove }: RemoveUrlQueryParams): string => {
+  const currentUrl = qs.parse(params);
+
+  keysToRemove.forEach((key) => delete currentUrl[key]);
+
+  return qs.stringifyUrl(
+    {
+      url: window.location.pathname,
+      query: currentUrl,
+    },
+    { skipNull: true },
+  );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,14 +16,21 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"]
+      "~/*": ["src/*"],
     },
     "plugins": [
       {
-        "name": "next"
-      }
-    ]
+        "name": "next",
+      },
+    ],
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "app/(blog)/blog/page.tsx", "app/(blog)/[slug]/page.jsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "app/(blog)/blog/page.tsx",
+    "app/(blog)/[slug]/page.jsx",
+  ],
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
Hi!
This commit introduces search functionality to the blog, enabling users to search for specific topics or keywords within blog posts. Additionally, pagination has been implemented to enhance user experience by breaking up long lists of posts into manageable segments. Thorough testing and coverage have been applied to ensure everything works as expected. The design methodology adheres to TailNext's design principles, and the code architecture maintains alignment with the existing structure.

The techniques used to implement this feature include Next.js searchParams and the query-string package.
[Next.js useSearchParams function](https://nextjs.org/docs/app/api-reference/functions/use-search-params)
[query-string package](https://www.npmjs.com/package/query-string)

Here is a demonstration of how it works in this video:
https://www.loom.com/share/1a735796b8d7400bb4b461ffef37cdba

(I also added an API doc for the functions within the utils.ts file.)

> [!IMPORTANT]
> The number of posts per page can be managed via the variable `POSTS_PER_PAGE`, defined as a constant at line 32 within `src/utils/posts.ts` file.